### PR TITLE
Updated docker-compose.yml: replaced broken images with latest

### DIFF
--- a/apim-tutorial/docker-compose.yml
+++ b/apim-tutorial/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
     api-manager:
-      image: wso2/wso2am:4.1.0
+      image: wso2/wso2am:latest
       healthcheck:
         test: ["CMD", "nc", "-z","localhost", "9443"]
         interval: 10s
@@ -24,7 +24,7 @@ services:
       build: 
         context: ./dockerfiles/micro-integrator/
         args:
-          - BASE_IMAGE=wso2/wso2mi:4.1.0
+          - BASE_IMAGE=wso2/wso2mi:latest
       healthcheck:
         test: ["CMD", "nc", "-z","localhost", "8290"]
         interval: 10s
@@ -51,7 +51,7 @@ services:
       build: 
         context: ./dockerfiles/streaming-integrator/
         args:
-          - BASE_IMAGE=wso2/wso2si:4.1.0
+          - BASE_IMAGE=wso2/wso2si:latest
       healthcheck:
         test: ["CMD", "nc", "-z","localhost", "9443"]
         interval: 10s


### PR DESCRIPTION
The docker-compose.yml contained references to 3 images with version '4.1.0'. However, those images don't exist (anymore?).

Therefore I updated these 3 references to point to version 'latest'. At this moment this will effectively result in version '4.0.0' being downloaded.

## Purpose
Resolves issues:
https://github.com/wso2/docs-apim/issues/7405
https://github.com/wso2/samples-apim/issues/118

## Goals
In stead of referencing a non-existent version of 3 images, this fix points to the 'latest' version of these images.

## Approach
Replaced 3 entries of '4.1.0' in the docker-compose.yml to version 'latest'. At this moment this will effectively result in version '4.0.0' being downloaded

## User stories
Enables https://apim.docs.wso2.com/en/latest/tutorials/scenarios/scenario-overview to works again.

## Release note
Fixed broken image(-link)s.

## Documentation
https://apim.docs.wso2.com/en/latest/tutorials/scenarios/scenario-overview

## Training
https://apim.docs.wso2.com/en/latest/tutorials/scenarios/scenario-overview

## Certification
N/A. The docker-compose was simply broken.

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
Just clone latest version.

## Test environment
N/A

## Learning
https://github.com/wso2/samples-apim/issues/118#issuecomment-1779138182