### PR TITLE
Casting the responseSize parameter from Integer to Long and fixing a …

### DIFF
--- a/thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.java
+++ b/thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.java
@@ -147,36 +147,17 @@ public class ThriftMetricEventBuilder extends AbstractMetricEventBuilder {
             Object propertyValue = property.getValue();
 
             switch (propertyKey) {
-                case APPLICATION_CONSUMER_KEY:
-                case API_CONTEXT:
-                case API_RESOURCE_PATH:
-                case API_TIER:
-                case API_HOSTNAME:
-                case HOST_NAME:
-                case HOSTNAME:
-                case USER_TENANT_DOMAIN:
-                case THROTTLED_OUT:
-                case RESPONSE_TIME:
-                case SERVICE_TIME:
-                case BACKEND_TIME:
                 case RESPONSE_SIZE:
-                case PROTOCOL:
-                case SECURITY_LATENCY:
-                case THROTTLING_LATENCY:
-                case OTHER_LATENCY:
-                case LABEL:
-                case ERROR_CODE:
-                case ERROR_MESSAGE:
-                case SUBSCRIBER:
-                case THROTTLED_OUT_REASON:
-                case THROTTLED_OUT_TIMESTAMP:
-                case USERNAME:
+                    // Changing the type from long to int as the responseSize is calculated as an int in newer versions of APIM
+                    eventMap.put(propertyKey,Long.parseLong(propertyValue.toString()));
+                    break;
                 case USER_NAME:
                     // Put to root level
                     eventMap.put(getRenamedKey(propertyKey), propertyValue);
                     break;
                 default:
                     customProperties.put(propertyKey, propertyValue);
+                    eventMap.put(propertyKey, propertyValue);
             }
         }
         eventMap.put(PROPERTIES_KEY, customProperties);

--- a/thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.java
+++ b/thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.java
@@ -149,15 +149,37 @@ public class ThriftMetricEventBuilder extends AbstractMetricEventBuilder {
             switch (propertyKey) {
                 case RESPONSE_SIZE:
                     // Changing the type from long to int as the responseSize is calculated as an int in newer versions of APIM
-                    eventMap.put(propertyKey,Long.parseLong(propertyValue.toString()));
+                    eventMap.put(getRenamedKey(propertyKey), Long.parseLong(propertyValue.toString()));
                     break;
+                case APPLICATION_CONSUMER_KEY:
+                case API_CONTEXT:
+                case API_RESOURCE_PATH:
+                case API_TIER:
+                case API_HOSTNAME:
+                case HOST_NAME:
+                case HOSTNAME:
+                case USER_TENANT_DOMAIN:
+                case THROTTLED_OUT:
+                case RESPONSE_TIME:
+                case SERVICE_TIME:
+                case BACKEND_TIME:
+                case PROTOCOL:
+                case SECURITY_LATENCY:
+                case THROTTLING_LATENCY:
+                case OTHER_LATENCY:
+                case LABEL:
+                case ERROR_CODE:
+                case ERROR_MESSAGE:
+                case SUBSCRIBER:
+                case THROTTLED_OUT_REASON:
+                case THROTTLED_OUT_TIMESTAMP:
+                case USERNAME:
                 case USER_NAME:
                     // Put to root level
                     eventMap.put(getRenamedKey(propertyKey), propertyValue);
                     break;
                 default:
                     customProperties.put(propertyKey, propertyValue);
-                    eventMap.put(propertyKey, propertyValue);
             }
         }
         eventMap.put(PROPERTIES_KEY, customProperties);


### PR DESCRIPTION
## Purpose
> In newer versions of APIM, the responseSize is extracted as an Integer. However, in the thrift-publisher event schema, it is defined an a Long. As a result the event publishing fails at the runtime. In order to fix this problem, we need to cast the responseSize parameter to a Long value before inserting it to the event map. 

> In addition, in the current implementation, there multiple case blocks in the switch without a break. As a result, the moment the parameter matches the value in the case, it goes into that block and all the other case blocks as well. In order to resolve this issue, the unnecessary code blocks have been removed. 


