### PR TITLE
Set Default Values for Special Attributes

### DIFF
--- a/thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.java
+++ b/thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.java
@@ -111,6 +111,7 @@ public class ThriftMetricEventBuilder extends AbstractMetricEventBuilder {
             if (!eventMap.containsKey(Constants.API_METHOD)) {
                 eventMap.put(Constants.API_METHOD, "PUBLISH");
             }
+            sanitizeNullableAttributes();
             for (Map.Entry<String, Class> entry : requiredAttributes.entrySet()) {
                 Object attribute = eventMap.get(entry.getKey());
                 if (attribute == null) {
@@ -124,6 +125,23 @@ public class ThriftMetricEventBuilder extends AbstractMetricEventBuilder {
             }
         }
         return true;
+    }
+
+
+    /**
+     * This method sets default values for special attributes that are missing or can be null in the event map.
+     *
+     * For example, the `applicationConsumerKey` may be null in scenarios where not all applications generate keys—
+     * such as APIs that use API keys or unsecured APIs. In such cases,
+     * we explicitly set `applicationConsumerKey` to "UNKNOWN".
+     */
+    private void sanitizeNullableAttributes() {
+        String[] nullableAttributes = {APPLICATION_CONSUMER_KEY};
+        for (String attribute : nullableAttributes) {
+            if (!eventMap.containsKey(attribute) || eventMap.get(attribute) == null) {
+                eventMap.put(attribute, "UNKNOWN");
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Purpose
This pull request introduces a new method, `sanitizeNullableAttributes`, to ensure that certain nullable attributes in the event map are sanitized with default values if they are missing or null. This change improves the robustness of the `validate` method in the `ThriftMetricEventBuilder` class.

### Enhancements to attribute handling:

* **Added `sanitizeNullableAttributes` method**: A new private method was introduced to set default values for specific nullable attributes, such as `APPLICATION_CONSUMER_KEY`, which is set to `"UNKNOWN"` if it is missing or null. This ensures consistent handling of attributes that may not always be present in the event map. (`[thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.javaR130-R146](diffhunk://#diff-28448ec633241e6f0e24bde2f9cba425b15a8ccfca0abf469431bf1f25eb721fR130-R146)`)

* **Integrated `sanitizeNullableAttributes` into `validate` method**: The `sanitizeNullableAttributes` method is now called at the beginning of the `validate` method to sanitize the event map before validation logic is executed. (`[thrift-analytics-publisher/src/main/java/org/wso2/am/thrift/analytics/publisher/ThriftMetricEventBuilder.javaR114](diffhunk://#diff-28448ec633241e6f0e24bde2f9cba425b15a8ccfca0abf469431bf1f25eb721fR114)`)