### PR TITLE
Update WSO2 component and MySQL image versions and add platform declarations to services.

### DIFF
--- a/apim-tutorial/docker-compose.yml
+++ b/apim-tutorial/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '2.4'
 services:
     api-manager:
-      image: wso2/wso2am:4.1.0
+      image: wso2/wso2am:4.3.0
+      platform: linux/amd64
       healthcheck:
         test: ["CMD", "nc", "-z","localhost", "9443"]
         interval: 10s
@@ -24,7 +24,8 @@ services:
       build: 
         context: ./dockerfiles/micro-integrator/
         args:
-          - BASE_IMAGE=wso2/wso2mi:4.1.0
+          - BASE_IMAGE=wso2/wso2mi:4.5.0
+      platform: linux/amd64
       healthcheck:
         test: ["CMD", "nc", "-z","localhost", "8290"]
         interval: 10s
@@ -51,7 +52,8 @@ services:
       build: 
         context: ./dockerfiles/streaming-integrator/
         args:
-          - BASE_IMAGE=wso2/wso2si:4.1.0
+          - BASE_IMAGE=wso2/wso2si:4.3.1
+      platform: linux/amd64
       healthcheck:
         test: ["CMD", "nc", "-z","localhost", "9443"]
         interval: 10s
@@ -65,6 +67,7 @@ services:
       cpus: 0.5
     backend-service:
       build: ./dockerfiles/backends/
+      platform: linux/amd64
       healthcheck:
         test: ["CMD", "nc", "-z","localhost", "8080"]
         interval: 10s
@@ -76,7 +79,8 @@ services:
       mem_reservation: 128M
       cpus: 1
     db:
-      image: mysql:8.0.23
+      image: mysql:8.0
+      platform: linux/amd64
       ports:
         - 8083:3306
       command: --init-file /data/application/init.sql
@@ -95,6 +99,7 @@ services:
       cpus: 0.5
     scripts:
       build: ./dockerfiles/scripts
+      platform: linux/amd64
       mem_limit: 256m
       mem_reservation: 128M
       cpus: 1

--- a/apim-tutorial/docker-compose.yml
+++ b/apim-tutorial/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       mem_reservation: 128M
       cpus: 1
     db:
-      image: mysql:8.0
+      image: mysql:8.0.44
       platform: linux/amd64
       ports:
         - 8083:3306


### PR DESCRIPTION
This pull request updates the `apim-tutorial/docker-compose.yml` file to use newer versions of several service images and ensures all services run on the `linux/amd64` platform. These changes improve compatibility and maintain up-to-date dependencies.

**Image version upgrades:**

* Updated `api-manager` image from `wso2/wso2am:4.1.0` to `wso2/wso2am:4.3.0` for improved features and fixes.
* Updated `micro-integrator` build base image from `wso2/wso2mi:4.1.0` to `wso2/wso2mi:4.5.0`.
* Updated `streaming-integrator` build base image from `wso2/wso2si:4.1.0` to `wso2/wso2si:4.3.1`.
* Updated `db` image from `mysql:8.0.23` to `mysql:8.0` for a more general and potentially updated version.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

This commit updates image versions for WSO2 components and MySQL and adds platform declarations to services in docker-compose.yml. The changes address two issues encountered when bringing up the tutorial samples:
- Outdated image tags causing incompatibilities with latest host Docker runtimes and sample expectations.
- Failure to start services on Apple Silicon (arm64) hosts due to images defaulting to amd64; adding explicit `platform: linux/amd64` ensures consistent behavior across architectures.

Resolves: N/A (no linked issue)

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Pin WSO2 component and MySQL images to tested, compatible tags.
- Add `platform` declarations to services so the apim-tutorial docker-compose works reliably on both Intel and Apple Silicon Macs and CI runners.
- Reduce "it works on my machine" variability for contributors and CI by making the composition reproducible.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

- Edited docker-compose.yml to:
  - Bump the WSO2 component images and MySQL image to the updated tags used in testing.
  - Add `platform: linux/amd64` to the affected service definitions.
- No code, API, or behavioural changes; this is an infrastructure/sample environment update.

## User stories
> Summary of user stories addressed by this change

- As a developer, I can bring up the apim-tutorial sample locally on Apple Silicon and Intel Macs without manual image overrides.
- As a reviewer/CI, I can rely on the same images and platform settings across environments to reproduce issues reliably.
- As a contributor, I don’t need to chase transient image compatibility problems when running the tutorial.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Updated apim-tutorial docker-compose: bumped WSO2 and MySQL image versions and added platform declarations for improved cross-architecture compatibility.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A — This change only affects local tutorial/sample orchestration (docker-compose.yml) and does not change public product behavior or APIs.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

N/A — No impact on certification content or exam material.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A

## Automation tests
 - Unit tests 
   > Code coverage information: N/A — no code changes.
 - Integration tests
   > Details about the test cases and coverage: No automated tests added. Manual smoke test performed by bringing up the compose stack locally on Intel and Apple Silicon hosts.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
   > yes
 - Ran FindSecurityBugs plugin and verified report? yes/no
   > no — not applicable for this compose-only change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
   > yes

## Samples
> Provide high-level details about the samples related to this feature

This change updates the apim-tutorial sample orchestration to use compatible image tags and platform declarations so the sample can be run reliably by contributors and testers on different host architectures.

## Related PRs
> List any other related PRs

None.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

No migration required. Users running the apim-tutorial compose should pull the updated images; adding `platform: linux/amd64` enforces pulling the amd64 variant where necessary.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

- Host OS: macOS (Intel and Apple Silicon) — local testing
- Docker Desktop: 4.x on macOS (Docker Engine 20.10+)
- Docker Compose: Compose v2 (docker-compose plugin)
- Images: WSO2 component images and MySQL (tags updated in commit)
- No browser or JDK functional changes involved.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

- Referenced Docker multi-arch documentation and common guidance for Apple Silicon (arm64) hosts to handle images that lack native arm builds.
- Verified recommended WSO2 Docker image tags from internal image references / DockerHub to select compatible versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container images to newer releases (API Manager 4.3.0, Micro Integrator 4.5.0, Streaming Integrator 4.3.1, MySQL 8.0.44).
  * Improved deployment consistency by specifying platform requirements (linux/amd64) for services and scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->