### PR TITLE
Add sample backend server for validating custom authorization tokens

### DIFF
--- a/custom-auth-token-backend/README.md
+++ b/custom-auth-token-backend/README.md
@@ -1,0 +1,104 @@
+# Custom Authorization Token - Sample Validation Backend
+
+A sample backend server for testing the "Passing a Custom Authorization Token
+to the Backend" feature. It accepts **any path and method**, and authorizes a
+request only when the header is exactly:
+
+```
+Authorization: Bearer 1234
+```
+
+On success it returns HTTP 200 with `"Request Received."`; otherwise HTTP 401.
+Every response also echoes back the headers the backend actually received, so
+you can verify what the gateway forwarded.
+
+## Run
+
+```bash
+python3 server.py          # listens on port 8080
+python3 server.py 9090     # or pick a port
+```
+
+Incoming requests and their headers are printed directly to the terminal.
+
+## Use as the API endpoint
+
+In the API Publisher, set the API's endpoint to:
+
+```
+http://localhost:8080/custom-auth-header/validate-header
+```
+
+(Use your machine's LAN IP instead of `localhost` if the gateway runs in
+Docker/Kubernetes or on another host - e.g. `http://host.docker.internal:8080/...`
+for Docker Desktop on macOS.)
+
+## Test methods
+
+### 1. Test the backend directly (no gateway)
+
+```bash
+# Expected: 200 "Request Received."
+curl -i -H "Authorization: Bearer 1234" http://localhost:8080/custom-auth-header/validate-header
+
+# Expected: 401 invalid_token
+curl -i -H "Authorization: Bearer some-app-token" http://localhost:8080/custom-auth-header/validate-header
+
+# Expected: 401 missing_token
+curl -i http://localhost:8080/custom-auth-header/validate-header
+```
+
+### 2. Test through the gateway WITHOUT the policy (baseline)
+
+Before attaching the TokenExchange policy, invoke the API:
+
+```bash
+curl -k -H "Authorization: Bearer <access-token>" -H "Custom: Bearer 1234" \
+  https://localhost:8243/testcustomheader/1.0.0
+```
+
+Expected: **401** from the backend, and the echoed headers should show either
+no `Authorization` header (gateway dropped it) plus a `Custom` header still
+present. This confirms the baseline behavior.
+
+### 3. Test through the gateway WITH the policy attached
+
+Attach the **Custom Authorization Token** policy (tokenExchange.j2) to the
+resource, deploy a new revision, then run the same command:
+
+```bash
+curl -k -H "Authorization: Bearer <access-token>" -H "Custom: Bearer 1234" \
+  https://localhost:8243/testcustomheader/1.0.0
+```
+
+Expected: **200** with `"Request Received."`. In `received_headers`, verify:
+
+- `Authorization` is `Bearer 1234` (swapped in from `Custom`)
+- `Custom` is absent (removed by the sequence)
+- the original application access token appears nowhere
+
+### 4. Negative tests through the gateway
+
+```bash
+# Wrong custom token -> backend 401 invalid_token
+curl -k -H "Authorization: Bearer <access-token>" -H "Custom: Bearer 9999" \
+  https://localhost:8243/testcustomheader/1.0.0
+
+# Missing Custom header -> backend 401 missing_token
+curl -k -H "Authorization: Bearer <access-token>" \
+  https://localhost:8243/testcustomheader/1.0.0
+
+# Invalid access token -> 401 from the GATEWAY (never reaches the backend;
+# server console shows no request)
+curl -k -H "Authorization: Bearer garbage" -H "Custom: Bearer 1234" \
+  https://localhost:8243/testcustomheader/1.0.0
+```
+
+### 5. Debugging tips
+
+- The server console log tells you whether a request reached the backend at
+  all, and with which headers - the fastest way to tell a gateway-side 401
+  from a backend-side 401.
+- If the deployed revision doesn't reflect the policy, redeploy the revision -
+  policies attached after deployment are not applied until a new revision is
+  deployed.

--- a/custom-auth-token-backend/server.py
+++ b/custom-auth-token-backend/server.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Sample backend that validates a custom Authorization token.
+
+Mimics the JAX-RS backend from the WSO2 APIM "Passing a Custom Authorization
+Token to the Backend" tutorial: it accepts requests only when the
+Authorization header is exactly "Bearer 1234" and replies "Request Received".
+
+It also echoes back all received headers in the JSON response so you can see
+exactly what the gateway forwarded — useful for verifying that:
+  - the original Authorization (application access token) was dropped
+  - the Custom header value was moved into Authorization
+  - the Custom header itself was removed
+
+Usage:
+    python3 server.py [port]      # default port 8080
+"""
+
+import json
+import sys
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+EXPECTED_TOKEN = "Bearer 1234"
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+
+
+class AuthValidationHandler(BaseHTTPRequestHandler):
+
+    def _respond(self, status, body):
+        payload = json.dumps(body, indent=2).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _handle(self):
+        auth = self.headers.get("Authorization")
+        custom = self.headers.get("Custom")
+        received_headers = dict(self.headers.items())
+
+        print(f"\n--- {datetime.now().isoformat()} {self.command} {self.path}")
+        for k, v in received_headers.items():
+            print(f"    {k}: {v}")
+
+        if auth == EXPECTED_TOKEN:
+            self._respond(200, {
+                "message": "Request Received.",
+                "status": "authorized",
+                "note": "Authorization header matched the expected custom token.",
+                "received_headers": received_headers,
+            })
+        elif auth is None:
+            self._respond(401, {
+                "message": "Unauthorized",
+                "status": "missing_token",
+                "note": "No Authorization header reached the backend. "
+                        "The gateway may have dropped it without applying the "
+                        "TokenExchange policy.",
+                "received_headers": received_headers,
+            })
+        else:
+            self._respond(401, {
+                "message": "Unauthorized",
+                "status": "invalid_token",
+                "note": f"Expected '{EXPECTED_TOKEN}' but got '{auth}'. "
+                        "If this is the application access token, the "
+                        "Custom->Authorization swap did not happen.",
+                "custom_header_seen": custom,
+                "received_headers": received_headers,
+            })
+
+    # Accept every method/path so any API resource mapping works
+    do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = _handle
+
+
+if __name__ == "__main__":
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), AuthValidationHandler)
+    print(f"Custom auth validation backend listening on http://0.0.0.0:{PORT}")
+    print(f"Expecting header ->  Authorization: {EXPECTED_TOKEN}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")


### PR DESCRIPTION

## Purpose

The sample backend endpoint
(`http://wso2cloud-custom-auth-header-sample-1-0-0.wso2apps.com/custom-auth-header/validate-header`)
referenced in the [Passing a Custom Authorization Token to the Backend](https://apim.docs.wso2.com/en/latest/api-gateway/policies/passing-a-custom-authorization-token-to-the-backend/) documentation is currently not working, leaving no way to test this feature.

This PR adds a lightweight, dependency-free Python backend as a replacement.
The server authorizes a request only when it carries `Authorization: Bearer 1234`, returning `200 "Request Received."` on success and `401` otherwise.

Every response echoes back the headers the backend received, making it easy to verify that the gateway's TokenExchange policy dropped the application access token, swapped the `Custom` header into `Authorization`, and removed the `Custom` header.

## Changes

- `server.py` — sample validation backend (Python stdlib only, no dependencies)
- `README.md` — run instructions and step-by-step test methods (direct, with/without policy, negative cases)

## How to test

```bash
python3 server.py    # starts on port 8080
curl -i -H "Authorization: Bearer 1234" http://localhost:8080/validate-header
```

See `README.md` for the full gateway test flow.